### PR TITLE
fix: unescaped characters error when use custom fetch function

### DIFF
--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -103,7 +103,7 @@ export function getSDK({
       await rateLimit();
 
       const queryStr = qs(query);
-      const url = baseUrl + path + queryStr;
+      const { href:url } = new URL(baseUrl + path + queryStr);
 
       reporter?.info(`Request ${url}`);
       const res = await fetchFn(url, {


### PR DESCRIPTION
Problem code:
```javascript
const { getSDK } = require('@mokoko/sdk');
const axios = require('axios');

async function LooseFetchFn(url, init) {
	const res = await axios({
		url,
		...init,
	});
	return {
		status: res.status,
		statusText: res.statusText,
		json: () => res.data,
	};
}

const sdk = getSDK({
	fetchFn: LooseFetchFn,
	apiKey: 'API_KEY',
});

sdk.armoriesGetProfileInfo('라라벨냥이')
	.then(console.log);
```

Error message:
```
node:internal/errors:464
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters
    at new NodeError (node:internal/errors:371:5)
    at new ClientRequest (node:_http_client:154:13)
    at Object.request (node:https:353:10)
    at RedirectableRequest._performRequest (/home/youn/proj/node/test/node_modules/follow-redirects/index.js:279:24)
    at new RedirectableRequest (/home/youn/proj/node/test/node_modules/follow-redirects/index.js:61:8)
    at Object.request (/home/youn/proj/node/test/node_modules/follow-redirects/index.js:487:14)
    at dispatchHttpRequest (/home/youn/proj/node/test/node_modules/axios/lib/adapters/http.js:202:25)
    at new Promise (<anonymous>)
    at httpAdapter (/home/youn/proj/node/test/node_modules/axios/lib/adapters/http.js:46:10)
    at dispatchRequest (/home/youn/proj/node/test/node_modules/axios/lib/core/dispatchRequest.js:53:10) {
  code: 'ERR_UNESCAPED_CHARACTERS'
}
```

Solution:
Force URL to be encoded as UTF-8 in sdk.ts `tryRequest` method.

```typescript
const { href:url } = new URL(baseUrl + path + queryStr);
```
